### PR TITLE
fix: honour extra_model_paths.yaml for refmods storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes are tracked here. Each version is also published as a
 so you can keep using an older version if a new one changes something you
 rely on.
 
+## Unreleased
+
+### Fixed
+
+- Mod storage honours `extra_model_paths.yaml`: a registered `refmods` path
+  is used for saving and every registered path is scanned when listing mods,
+  instead of always hardcoding `models/refmods` ([#4](https://github.com/Luisacaotica/ComfyUI-MiniMaxH3Mod/issues/4)).
+
 ## v0.1.0 — 2026-08-16
 
 First tagged release. Extract references once as tiny `.safetensors`

--- a/common.py
+++ b/common.py
@@ -12,13 +12,19 @@ VIDEO_EXTS = {".mp4", ".webm", ".mov", ".mkv", ".avi", ".m4v"}
 
 
 def refmods_dir() -> str:
-    """ComfyUI models/refmods — the mod storage folder, created on first use.
+    """The mod storage folder, created on first use.
 
-    Sits next to loras/, unet/ etc. instead of inside the pack folder, so mods
-    live in the standard model tree.
+    A "refmods" path registered with ComfyUI (e.g. via extra_model_paths.yaml)
+    wins; otherwise models/refmods, next to loras/ unet/ etc.  First existing
+    candidate is used, so a YAML mapping only takes over once it is real.
     """
     import folder_paths
-    d = os.path.join(folder_paths.models_dir, "refmods")
+    try:
+        paths = list(folder_paths.get_folder_paths("refmods"))
+    except KeyError:
+        paths = []
+    paths.append(os.path.join(folder_paths.models_dir, "refmods"))
+    d = next((p for p in paths if os.path.isdir(p)), paths[0])
     os.makedirs(d, exist_ok=True)
     return d
 

--- a/nodes.py
+++ b/nodes.py
@@ -150,11 +150,17 @@ def _h3_pack_submodule(subpath: str):
 # ═══════════════════════════════════════════════════════════════════════════
 
 def _mod_search_dirs() -> List[str]:
-    dirs = [refmods_dir()]
+    """Every folder scanned for mods: the primary refmods dir, any other
+    registered "refmods" path (extra_model_paths.yaml), then legacy locations."""
+    try:
+        registered = list(folder_paths.get_folder_paths("refmods"))
+    except KeyError:
+        registered = []
     root_models_mods = os.path.join(
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
         "models", "mods")
-    for d in (root_models_mods, LEGACY_MODS_DIR):
+    dirs: List[str] = []
+    for d in [refmods_dir()] + registered + [root_models_mods, LEGACY_MODS_DIR]:
         if d not in dirs and os.path.isdir(d):
             dirs.append(d)
     return dirs


### PR DESCRIPTION
Fixes #4.

`refmods_dir()` hardcoded `models/refmods`, so a `refmods` path registered via `extra_model_paths.yaml` was never used — breaking multi-drive / external storage setups.

- `common.py` — `refmods_dir()` queries `folder_paths.get_folder_paths("refmods")` first, falling back to `models/refmods`. Picks the first candidate that **exists**, so a YAML path on an unmounted drive can't break saves.
- `nodes.py` — `_mod_search_dirs()` scans every registered `refmods` path (plus the legacy dirs), so mods on external storage show up in the loader dropdown.

Graph presets and mod saving inherit this via `refmods_dir()`.

Verified with a stubbed `folder_paths`: nothing registered → default; YAML path present → wins; YAML path missing → falls back to the existing default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mod storage now respects registered `refmods` paths from `extra_model_paths.yaml`.
  * Mods are saved to the first available configured location, with `models/refmods` used as a fallback.
  * Mod listings now scan all configured `refmods` directories, along with supported legacy locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->